### PR TITLE
3 0 stable

### DIFF
--- a/app/helpers/spree/blog_entries_helper.rb
+++ b/app/helpers/spree/blog_entries_helper.rb
@@ -22,11 +22,11 @@ module Spree
     end
 
     def blog_full_article_html(blog_entry)
-      "<br><br>Read the full article #{link_to blog_entry.title, blog_entry_url_permalink(blog_entry)} at #{link_to "#{Spree::Config[:site_name]} Blog", blog_url}."
+      "<br><br>Read the full article #{link_to blog_entry.title, blog_entry_url_permalink(blog_entry)} at #{link_to "#{Spree::Store.current.name} Blog", blog_url}."
     end
 
     def blog_first_appeared_html(blog_entry)
-      "<br><br>The article #{link_to blog_entry.title, blog_entry_url_permalink(blog_entry)} first appeared on #{link_to "#{Spree::Config[:site_name]} Blog", blog_url}."
+      "<br><br>The article #{link_to blog_entry.title, blog_entry_url_permalink(blog_entry)} first appeared on #{link_to "#{Spree::Store.current.name} Blog", blog_url}."
     end
 
     def blog_entry_tag_list_html blog_entry

--- a/app/views/spree/blog_entries/feed.rss.builder
+++ b/app/views/spree/blog_entries/feed.rss.builder
@@ -1,7 +1,7 @@
 xml.instruct! :xml, :version => "1.0" 
 xml.rss :version => "2.0" do
   xml.channel do
-    xml.title "#{Spree::Config[:site_name]} Blog"
+    xml.title "#{Spree::Store.current.name} Blog"
     xml.description ""
     xml.link blog_url
 

--- a/db/migrate/20150213140632_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/20150213140632_add_taggings_counter_cache_to_tags.rb
@@ -1,0 +1,16 @@
+require 'acts-as-taggable-on'
+
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20150213140726_add_missing_taggable_index.rb
+++ b/db/migrate/20150213140726_add_missing_taggable_index.rb
@@ -1,0 +1,9 @@
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20151103140826_change_collation_for_tag_names.rb
+++ b/db/migrate/20151103140826_change_collation_for_tag_names.rb
@@ -1,0 +1,9 @@
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/spree_blogging_spree.gemspec
+++ b/spree_blogging_spree.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0.rc5'
+  s.add_dependency 'spree_core', '~> 3.0.4'
   s.add_dependency 'acts-as-taggable-on', '~> 3.5.0'
 
   s.add_development_dependency 'capybara', '~> 2.2.1'


### PR DESCRIPTION
update spree_core to 3.0.4 stable.

fixes the following mysql error, which occurs while creating new blogs due to lack of migrations:

Mysql2::Error: Unknown column 'taggings_count' in 'field list': UPDATE `tags` SET `taggings_count` = COALESCE(`taggings_count`, 0) + 1 WHERE `tags`.`id` = 1
